### PR TITLE
Add writeBoolean, writeFormula, writeUrl methods to worksheet type

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,42 @@ main();
 ## Documentation
 
 See the examples directory.
+
+## Building
+
+To build the excelwriter package, first clone this repository then navigate to its root directory.
+
+```
+git clone https://github.com/mohd-akram/excelwriter
+cd excelwriter
+```
+
+Clone the [libxlsxwriter](https://github.com/jmcnamara/libxlsxwriter) git submodule dependency.
+
+```
+git submodule update --init --recursive
+```
+
+Ensure that [node-gyp](https://github.com/nodejs/node-gyp) is globally installed.
+
+```
+npm install -g node-gyp
+```
+
+Install JavaScript dependencies. This will also initially build the excelwriter package.
+
+```
+npm install
+```
+
+To rebuild the package after making changes, run:
+
+```
+node-gyp rebuild
+```
+
+Run an example script to test, like so:
+
+```
+(cd examples && node demo.js)
+```

--- a/examples/demo.js
+++ b/examples/demo.js
@@ -15,16 +15,28 @@ async function main() {
 
   /* Change the column width for clarity. */
   worksheet.setColumn(0, 0, 20);
+  
+  let row = 0;
 
   /* Write some simple text. */
-  worksheet.writeString(0, 0, "Hello");
+  worksheet.writeString(row++, 0, "Hello");
 
   /* Text with formatting. */
-  worksheet.writeString(1, 0, "World", format);
+  worksheet.writeString(row++, 0, "World", format);
+  
+  /* Write a url. */
+  worksheet.writeUrl(row++, 0, "https://www.npmjs.com/package/excelwriter");
 
   /* Write some numbers. */
-  worksheet.writeNumber(2, 0, 123);
-  worksheet.writeNumber(3, 0, 123.456);
+  worksheet.writeNumber(row++, 0, 123);
+  worksheet.writeNumber(row++, 0, 123.456);
+  
+  /* Write a formula. */
+  worksheet.writeFormula(row++, 0, "=5+5");
+  
+  /* Write booleans. */
+  worksheet.writeBoolean(row++, 0, false);
+  worksheet.writeBoolean(row++, 0, true);
 
   /* Insert an image. */
   worksheet.insertImage(1, 2, await fs.readFile("logo.png"));

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,10 +7,18 @@
     "": {
       "name": "excelwriter",
       "version": "0.2.1",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "node-addon-api": "^5.0.0"
+      },
+      "devDependencies": {
+        "excelwriter": "file:."
       }
+    },
+    "node_modules/excelwriter": {
+      "resolved": "",
+      "link": true
     },
     "node_modules/node-addon-api": {
       "version": "5.0.0",
@@ -19,6 +27,20 @@
     }
   },
   "dependencies": {
+    "excelwriter": {
+      "version": "file:",
+      "requires": {
+        "excelwriter": "file:",
+        "node-addon-api": "^5.0.0"
+      },
+      "dependencies": {
+        "node-addon-api": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.0.0.tgz",
+          "integrity": "sha512-CvkDw2OEnme7ybCykJpVcKH+uAOLV2qLqiyla128dN9TkEWfrYmxG6C2boDe5KcNQqZF3orkqzGgOMvZ/JNekA=="
+        }
+      }
+    },
     "node-addon-api": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -33,5 +33,8 @@
   "homepage": "https://github.com/mohd-akram/excelwriter#readme",
   "dependencies": {
     "node-addon-api": "^5.0.0"
+  },
+  "devDependencies": {
+    "excelwriter": "file:."
   }
 }

--- a/src/worksheet.cc
+++ b/src/worksheet.cc
@@ -38,8 +38,16 @@ Napi::Object Worksheet::Init(Napi::Env env, Napi::Object exports) {
               "setHeader",
               static_cast<napi_property_attributes>(napi_writable |
                                                     napi_configurable)),
+          InstanceMethod<&Worksheet::WriteBoolean>(
+              "writeBoolean",
+              static_cast<napi_property_attributes>(napi_writable |
+                                                    napi_configurable)),
           InstanceMethod<&Worksheet::WriteDatetime>(
               "writeDatetime",
+              static_cast<napi_property_attributes>(napi_writable |
+                                                    napi_configurable)),
+          InstanceMethod<&Worksheet::WriteFormula>(
+              "writeFormula",
               static_cast<napi_property_attributes>(napi_writable |
                                                     napi_configurable)),
           InstanceMethod<&Worksheet::WriteNumber>(
@@ -48,6 +56,10 @@ Napi::Object Worksheet::Init(Napi::Env env, Napi::Object exports) {
                                                     napi_configurable)),
           InstanceMethod<&Worksheet::WriteString>(
               "writeString",
+              static_cast<napi_property_attributes>(napi_writable |
+                                                    napi_configurable)),
+          InstanceMethod<&Worksheet::WriteUrl>(
+              "writeUrl",
               static_cast<napi_property_attributes>(napi_writable |
                                                     napi_configurable)),
       });
@@ -142,6 +154,16 @@ Napi::Value Worksheet::SetHeader(const Napi::CallbackInfo& info) {
   return env.Undefined();
 }
 
+Napi::Value Worksheet::WriteBoolean(const Napi::CallbackInfo& info) {
+  auto env = info.Env();
+  worksheet_write_boolean(worksheet,
+                          info[0].As<Napi::Number>(),
+                          info[1].As<Napi::Number>().Uint32Value(),
+                          info[2].As<Napi::Boolean>(),
+                          Format::Get(info[3]));
+  return env.Undefined();
+}
+
 Napi::Value Worksheet::WriteDatetime(const Napi::CallbackInfo& info) {
   auto env = info.Env();
   auto date = info[2].As<Napi::Object>();
@@ -156,6 +178,16 @@ Napi::Value Worksheet::WriteDatetime(const Napi::CallbackInfo& info) {
                            info[1].As<Napi::Number>().Uint32Value(),
                            info[2].As<Napi::Date>() / 1000 - offset,
                            Format::Get(info[3]));
+  return env.Undefined();
+}
+
+Napi::Value Worksheet::WriteFormula(const Napi::CallbackInfo& info) {
+  auto env = info.Env();
+  worksheet_write_formula(worksheet,
+                          info[0].As<Napi::Number>(),
+                          info[1].As<Napi::Number>().Uint32Value(),
+                          info[2].As<Napi::String>().Utf8Value().c_str(),
+                          Format::Get(info[3]));
   return env.Undefined();
 }
 
@@ -176,5 +208,15 @@ Napi::Value Worksheet::WriteString(const Napi::CallbackInfo& info) {
                          info[1].As<Napi::Number>().Uint32Value(),
                          info[2].As<Napi::String>().Utf8Value().c_str(),
                          Format::Get(info[3]));
+  return env.Undefined();
+}
+
+Napi::Value Worksheet::WriteUrl(const Napi::CallbackInfo& info) {
+  auto env = info.Env();
+  worksheet_write_url(worksheet,
+                      info[0].As<Napi::Number>(),
+                      info[1].As<Napi::Number>().Uint32Value(),
+                      info[2].As<Napi::String>().Utf8Value().c_str(),
+                      Format::Get(info[3]));
   return env.Undefined();
 }

--- a/src/worksheet.h
+++ b/src/worksheet.h
@@ -15,8 +15,11 @@ class Worksheet : public Napi::ObjectWrap<Worksheet> {
   Napi::Value SetRow(const Napi::CallbackInfo& info);
   Napi::Value SetFooter(const Napi::CallbackInfo& info);
   Napi::Value SetHeader(const Napi::CallbackInfo& info);
+  Napi::Value WriteBoolean(const Napi::CallbackInfo& info);
   Napi::Value WriteDatetime(const Napi::CallbackInfo& info);
+  Napi::Value WriteFormula(const Napi::CallbackInfo& info);
   Napi::Value WriteNumber(const Napi::CallbackInfo& info);
   Napi::Value WriteString(const Napi::CallbackInfo& info);
+  Napi::Value WriteUrl(const Napi::CallbackInfo& info);
   lxw_worksheet* worksheet = nullptr;
 };


### PR DESCRIPTION
The PR also includes new documentation in the readme about how to build the package, adds a devDependency so that examples run as-is, and uses the new methods in `examples/demo.js`.

I am exploring using this package in software that I maintain, and would need this additional functionality in order to do so. Other PRs may also follow, if I end up needing other parts of the libxlsxwriter API also exposed.