### PR TITLE
Add pane support

### DIFF
--- a/examples/panes.js
+++ b/examples/panes.js
@@ -1,0 +1,111 @@
+import fs from "fs/promises";
+
+import { Format, Workbook } from "excelwriter";
+
+/* Create a new workbook and add some worksheets. */
+const workbook = new Workbook();
+
+const worksheet1 = workbook.addWorksheet("Panes 1");
+const worksheet2 = workbook.addWorksheet("Panes 2");
+const worksheet3 = workbook.addWorksheet("Panes 3");
+const worksheet4 = workbook.addWorksheet("Panes 4");
+
+/* Set up some formatting and text to highlight the panes. */
+const header = workbook.addFormat();
+header.setAlign(Format.CENTER_ALIGN);
+header.setAlign(Format.VERTICAL_CENTER_ALIGN);
+header.setFgColor(0xd7e4bc);
+header.setBold();
+header.setBorder(Format.THIN_BORDER);
+
+const center = workbook.addFormat();
+center.setAlign(Format.CENTER_ALIGN);
+
+/*
+ * Example 1. Freeze pane on the top row.
+ */
+worksheet1.freezePanes(1, 0);
+
+/* Some sheet formatting. */
+worksheet1.setColumn(0, 8, 16);
+worksheet1.setRow(0, 20);
+worksheet1.setSelection(4, 3, 4, 3);
+
+/* Some worksheet text to demonstrate scrolling. */
+for (let col = 0; col < 9; col++) {
+  worksheet1.writeString(0, col, "Scroll down", header);
+}
+
+for (let row = 1; row < 100; row++) {
+  for (let col = 0; col < 9; col++) {
+    worksheet1.writeNumber(row, col, row + 1, center);
+  }
+}
+
+/*
+ * Example 2. Freeze pane on the left column.
+ */
+worksheet2.freezePanes(0, 1);
+
+/* Some sheet formatting. */
+worksheet2.setColumn(0, 0, 16);
+worksheet2.setSelection(4, 3, 4, 3);
+
+/* Some worksheet text to demonstrate scrolling. */
+for (let row = 0; row < 50; row++) {
+  worksheet2.writeString(row, 0, "Scroll right", header);
+
+  for (let col = 1; col < 26; col++) {
+    worksheet2.writeNumber(row, col, col, center);
+  }
+}
+
+/*
+ * Example 3. Freeze pane on the top row and left column.
+ */
+worksheet3.freezePanes(1, 1);
+
+/* Some sheet formatting. */
+worksheet3.setColumn(0, 25, 16);
+worksheet3.setRow(0, 20);
+worksheet3.writeString(0, 0, "", header);
+worksheet3.setSelection(4, 3, 4, 3);
+
+/* Some worksheet text to demonstrate scrolling. */
+for (let col = 1; col < 26; col++) {
+  worksheet3.writeString(0, col, "Scroll down", header);
+}
+
+for (let row = 1; row < 50; row++) {
+  worksheet3.writeString(row, 0, "Scroll right", header);
+
+  for (let col = 1; col < 26; col++) {
+    worksheet3.writeNumber(row, col, col, center);
+  }
+}
+
+/*
+ * Example 4. Split pane on the top row and left column.
+ *
+ * The divisions must be specified in terms of row and column dimensions.
+ * The default row height is 15 and the default column width is 8.43
+ */
+worksheet4.splitPanes(15, 8.43);
+
+/* Some sheet formatting. */
+
+/* Some worksheet text to demonstrate scrolling. */
+for (let col = 1; col < 26; col++) {
+  worksheet4.writeString(0, col, "Scroll", center);
+}
+
+for (let row = 1; row < 50; row++) {
+  worksheet4.writeString(row, 0, "Scroll", center);
+
+  for (let col = 1; col < 26; col++) {
+    worksheet4.writeNumber(row, col, col, center);
+  }
+}
+
+const data = workbook.close();
+await fs.writeFile("panes.xlsx", Buffer.from(data));

--- a/index.d.ts
+++ b/index.d.ts
@@ -126,6 +126,8 @@ declare namespace XLSX {
   }
 
   class Worksheet {
+    freezePanes(row: number, column: number): void;
+    splitPanes(vertical: number, horizontal: number): void;
     insertChart(row: number, column: number, chart: Chart): void;
     insertImage(row: number, column: number, image: Uint8Array): void;
     mergeRange(

--- a/src/worksheet.cc
+++ b/src/worksheet.cc
@@ -10,6 +10,10 @@ Napi::Object Worksheet::Init(Napi::Env env, Napi::Object exports) {
       env,
       "Worksheet",
       {
+          InstanceMethod<&Worksheet::FreezePanes>("freezePanes",
+                                                  napi_default_method),
+          InstanceMethod<&Worksheet::SplitPanes>("splitPanes",
+                                                 napi_default_method),
           InstanceMethod<&Worksheet::InsertChart>("insertChart",
                                                   napi_default_method),
           InstanceMethod<&Worksheet::InsertImage>("insertImage",
@@ -61,6 +65,21 @@ Napi::Value Worksheet::New(Napi::Env env, lxw_worksheet* worksheet) {
       ->Get("WorksheetConstructor")
       .As<Napi::Function>()
       .New({Napi::External<lxw_worksheet>::New(env, worksheet)});
+}
+
+Napi::Value Worksheet::FreezePanes(const Napi::CallbackInfo& info) {
+  auto env = info.Env();
+  worksheet_freeze_panes(worksheet,
+                         info[0].As<Napi::Number>(),
+                         info[1].As<Napi::Number>().Uint32Value());
+  return env.Undefined();
+}
+
+Napi::Value Worksheet::SplitPanes(const Napi::CallbackInfo& info) {
+  auto env = info.Env();
+  worksheet_split_panes(
+      worksheet, info[0].As<Napi::Number>(), info[1].As<Napi::Number>());
+  return env.Undefined();
 }
 
 Napi::Value Worksheet::InsertChart(const Napi::CallbackInfo& info) {

--- a/src/worksheet.h
+++ b/src/worksheet.h
@@ -8,6 +8,8 @@ class Worksheet : public Napi::ObjectWrap<Worksheet> {
   Worksheet(const Napi::CallbackInfo& info);
 
  private:
+  Napi::Value FreezePanes(const Napi::CallbackInfo& info);
+  Napi::Value SplitPanes(const Napi::CallbackInfo& info);
   Napi::Value InsertChart(const Napi::CallbackInfo& info);
   Napi::Value InsertImage(const Napi::CallbackInfo& info);
   Napi::Value MergeRange(const Napi::CallbackInfo& info);


### PR DESCRIPTION
This PR adds an API binding for `worksheet_freeze_panes`, used to freeze rows or columns. The successful behavior can be seen in the updated demo spreadsheet.

https://libxlsxwriter.github.io/worksheet_8h.html#a7e52f1eecb20fe4f9e6223bcf195103b
